### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
       RELEASE_VERSION: "${{ github.event.release.tag_name }}"
       RELEASE_DESCRIPTION: "${{ github.event.release.name }}"
       RELEASE_TYPE: "release"
-      SUBAPP_PATHS: "supervisely/serve, supervisely/calculator, supervisely/similarity-calculator, supervisely/labeling-tool, supervisely/retail-collection"
+      SUBAPP_PATHS: "__ROOT_APP__"

--- a/supervisely/calculator/config.json
+++ b/supervisely/calculator/config.json
@@ -9,7 +9,7 @@
     "nn tools"
   ],
   "description": "Calculate embeddings for images project",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "supervisely/calculator/src/main.py",
   "modal_template": "supervisely/calculator/src/modal.html",

--- a/supervisely/calculator/config.json
+++ b/supervisely/calculator/config.json
@@ -9,7 +9,7 @@
     "nn tools"
   ],
   "description": "Calculate embeddings for images project",
-  "docker_image": "supervisely/base-py-sdk:6.73.166",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.11.10",
   "main_script": "supervisely/calculator/src/main.py",
   "modal_template": "supervisely/calculator/src/modal.html",

--- a/supervisely/calculator/config.json
+++ b/supervisely/calculator/config.json
@@ -10,7 +10,7 @@
   ],
   "description": "Calculate embeddings for images project",
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "instance_version": "6.11.10",
+  "instance_version": "6.15.60",
   "main_script": "supervisely/calculator/src/main.py",
   "modal_template": "supervisely/calculator/src/modal.html",
   "modal_width": 700,

--- a/supervisely/calculator/dev_requirements.txt
+++ b/supervisely/calculator/dev_requirements.txt
@@ -1,0 +1,1 @@
+supervisely==6.73.564

--- a/supervisely/calculator/requirements.txt
+++ b/supervisely/calculator/requirements.txt
@@ -1,1 +1,1 @@
-supervisely[apps]==6.73.129
+supervisely[apps]==6.73.564

--- a/supervisely/labeling-tool/config.json
+++ b/supervisely/labeling-tool/config.json
@@ -9,7 +9,7 @@
     "labeling"
   ],
   "description": "Use metric learning models to classify images",
-  "docker_image": "supervisely/labeling:0.0.5",
+  "docker_image": "supervisely/labeling:6.73.564",
   "instance_version": "6.4.57",
   "main_script": "supervisely/labeling-tool/src/main.py",
   "gui_template": "supervisely/labeling-tool/src/gui.html",

--- a/supervisely/labeling-tool/config.json
+++ b/supervisely/labeling-tool/config.json
@@ -10,7 +10,7 @@
   ],
   "description": "Use metric learning models to classify images",
   "docker_image": "supervisely/labeling:6.73.564",
-  "instance_version": "6.4.57",
+  "instance_version": "6.15.60",
   "main_script": "supervisely/labeling-tool/src/main.py",
   "gui_template": "supervisely/labeling-tool/src/gui.html",
   "task_location": "application_sessions",

--- a/supervisely/labeling-tool/dev_requirements.txt
+++ b/supervisely/labeling-tool/dev_requirements.txt
@@ -1,2 +1,2 @@
-supervisely==6.72.82
-supervisely[apps]==6.72.82
+supervisely==6.73.564
+supervisely[apps]==6.73.564

--- a/supervisely/labeling-tool/requirements.txt
+++ b/supervisely/labeling-tool/requirements.txt
@@ -9,5 +9,5 @@ apex==0.9.10dev
 scikit_learn==0.23.2
 python-dotenv==0.19.2
 torch==1.11.0
-supervisely==6.35.0
-supervisely[apps]==6.35.0
+supervisely==6.73.564
+supervisely[apps]==6.73.564

--- a/supervisely/similarity-calculator/config.json
+++ b/supervisely/similarity-calculator/config.json
@@ -8,7 +8,7 @@
     "serve"
   ],
   "description": "Recommends matching items from the catalog",
-  "docker_image": "supervisely/base-py-sdk:6.35.0",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.4.57",
   "main_script": "supervisely/similarity-calculator/src/main.py",
   "gui_template": "supervisely/similarity-calculator/src/gui.html",

--- a/supervisely/similarity-calculator/config.json
+++ b/supervisely/similarity-calculator/config.json
@@ -9,7 +9,7 @@
   ],
   "description": "Recommends matching items from the catalog",
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "instance_version": "6.4.57",
+  "instance_version": "6.15.60",
   "main_script": "supervisely/similarity-calculator/src/main.py",
   "gui_template": "supervisely/similarity-calculator/src/gui.html",
   "modal_width": 700,

--- a/supervisely/similarity-calculator/requirements.txt
+++ b/supervisely/similarity-calculator/requirements.txt
@@ -9,5 +9,5 @@ apex==0.9.10dev
 scikit_learn==0.23.2
 python-dotenv==0.19.2
 torch==1.11.0
-supervisely==6.35.0
-supervisely[apps]==6.35.0
+supervisely==6.73.564
+supervisely[apps]==6.73.564

--- a/supervisely/similarity-calculator/src/sly_functions.py
+++ b/supervisely/similarity-calculator/src/sly_functions.py
@@ -13,7 +13,7 @@ import numpy as np
 from tqdm import tqdm
 from functools import lru_cache
 
-import supervisely_lib as sly
+import supervisely as sly
 
 import sly_globals as g
 import sly_progress

--- a/supervisely/visualization/config.json
+++ b/supervisely/visualization/config.json
@@ -9,7 +9,7 @@
   ],
   "description": "",
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "instance_version": "6.4.57",
+  "instance_version": "6.15.60",
   "main_script": "supervisely/visualization/src/sly_train.py",
   "gui_template": "supervisely/visualization/src/gui.html",
   "task_location": "workspace_tasks",

--- a/supervisely/visualization/config.json
+++ b/supervisely/visualization/config.json
@@ -8,7 +8,7 @@
     "nn tools"
   ],
   "description": "",
-  "docker_image": "supervisely/base-py-sdk:6.35.0",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.4.57",
   "main_script": "supervisely/visualization/src/sly_train.py",
   "gui_template": "supervisely/visualization/src/gui.html",

--- a/supervisely/visualization/requirements.txt
+++ b/supervisely/visualization/requirements.txt
@@ -9,5 +9,5 @@ apex==0.9.10dev
 scikit_learn==0.23.2
 python-dotenv==0.19.2
 torch==1.11.0
-supervisely==6.35.0
-supervisely[apps]==6.35.0
+supervisely==6.73.564
+supervisely[apps]==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
